### PR TITLE
Cite order and some other minor things

### DIFF
--- a/index.adoc
+++ b/index.adoc
@@ -1,5 +1,5 @@
 :bibtex-file: library.bib
-:bibtex-order: alphabetical
+:bibtex-order: appearance
 :bibtex-style: ieee
 :stem: asciimath
 :xrefstyle: short

--- a/sections/3_study.adoc
+++ b/sections/3_study.adoc
@@ -149,7 +149,7 @@ Participants also completed a pre-test on the morning of the experiment and a po
 Students participating in the study completed their tasks in an interactive tutoring system developed by the researchers.
 They communicated verbally through a skype connection.
 No video signal was transmitted.
-Gaze data was recorded using SMI RED250 eye trackers citenp:[SMIRED250IMotions, olsenUsingIntelligentTutoring2014].
+Gaze data was recorded using SMI RED250 eye trackers citenp:[olsenUsingIntelligentTutoring2014, SMIRED250IMotions].
 
 ===== Description of the Data
 

--- a/sections/4_implementation.adoc
+++ b/sections/4_implementation.adoc
@@ -249,7 +249,7 @@ Saccade velocity skewness has been shown to correlate with familiarity citenp:[p
 If the skewness is highly positive, that means that the overall saccade speeds were high.
 This indicates that the subject is familiar with the stimulus and can quickly maneuver to the relevant sections when seeking information.
 Saccade speed does not necessarily indicate expertise in the relevant subject matter.
-Non-expert participant could be familiar with the material and hence know where to look for information, but an expert would also quickly assert what information they are seeking.
+A non-expert participant could be familiar with the material and hence know where to look for information, but an expert would also quickly assert what information they are seeking.
 
 To calculate this feature, we calculated the speed by dividing the saccade length by the saccade duration.
 We then got the skew of the outputted distribution.

--- a/sections/4_implementation.adoc
+++ b/sections/4_implementation.adoc
@@ -200,7 +200,7 @@ Cognitive load has been shown to correlate with cognitive performance citenp:[he
 The Yerkes-Dodson law describes the relationship between the two, indicating an optimal plateau where a certain degree of cognitive workload is tied to maximized cognitive performance.
 If the cognitive workload is increased beyond this point, cognitive performance is diminished citenp:[hebbDrivesConceptualNervous1955].
 
-Our implementation of LHIPA is based on the code found in citenp:[duchowskiIndexPupillaryActivity2018, duchowskiLowHighIndex2020].
+Our implementation of LHIPA is based on the code found in citenp:[duchowskiLowHighIndex2020, duchowskiIndexPupillaryActivity2018].
 
 ==== Gaze Characteristics
 
@@ -400,7 +400,7 @@ The effect of different methods for reducing the feature space on generalizabili
 The method we use for dimensionality reduction is Principal Component Analysis (PCA), and the one for feature selection is Least Absolute Shrinkage and Selection Operator (LASSO).
 For all pipelines, we also use a zero-variance filter to remove the features that have no variance in their data
 
-LASSO was selected as our feature selection algorithm because it has been shown to perform very well when the number of samples is less than the number of features citenp:[tibshiraniRegressionShrinkageSelection1996, giannakosMultimodalDataMeans2019], which is the case for most of our feature groups.
+LASSO was selected as our feature selection algorithm because it has been shown to perform very well when the number of samples is less than the number of features citenp:[giannakosMultimodalDataMeans2019, tibshiraniRegressionShrinkageSelection1996], which is the case for most of our feature groups.
 
 
 ==== Prediction: Ensemble Learning
@@ -410,7 +410,7 @@ An ensemble combines several different base regressors or classifiers in order t
 A voting regressor is an ensemble that fits several regressors, each on the whole dataset.
 Then it averages the individual predictions respective to their given weights to form a final prediction.
 To find the weights for the voting, we perform cross-validation, with the validation set, on each regressor and set their respective weights to 1 - Root Mean Square Error (RMSE).
-Many studies have been published that demonstrate that ensemble methods frequently improve on the average performance of the single regressor citenp:[kunchevaCombiningPatternClassifiers, anOptimalWeightSelectionRegressor2009].
+Many studies have been published that demonstrate that ensemble methods frequently improve on the average performance of the single regressor citenp:[anOptimalWeightSelectionRegressor2009, kunchevaCombiningPatternClassifiers].
 
 KNN predictors approximate the target by associating it with its n nearest neighbors in the training set.
 KNNs are simplistic algorithms that, despite their simplicity, in some cases, outperform more complex learning algorithms.

--- a/sections/5_results.adoc
+++ b/sections/5_results.adoc
@@ -143,10 +143,10 @@ Nine of the ten more generalizable pipelines contain this combination of dataset
 LASSO is the most represented method of feature space reduction among the more generalizable pipelines.
 We note that there are more pipelines with LASSO that beat the baseline and might explain the trend we are seeing.
 LASSO is also included in the two pipelines with the best FGI.
-PCA performs very well for the feature groups ALL and heatmap; this might be explained by the fact that these are the largest feature groups with hundreds of thousands of values.
+PCA performs very well for the feature groups All and heatmap; this might be explained by the fact that these are the largest feature groups with hundreds of thousands of values.
 
 Seven of our twelve feature groups are represented among the ten most generalizable pipelines.
-However, three feature groups show up more than once, ALL, Heatmaps, and GARCH.
+However, three feature groups show up more than once, All, Heatmaps, and GARCH.
 This indicates that they might be more generalizable feature groups.
 It should also be noted that GARCH is also the only pipeline with an in-study dataset that is not fractions_cscw of the ten most generalizable pipelines.
 
@@ -168,4 +168,4 @@ As with the generalizable pipelines, there are more pipelines with LASSO that be
 For the feature groups, we observe some differences from the generalizable pipelines.
 ARMA, LHIPA, Gaze Characteristics, and Pupil Diameter are present in the context-sensitive pipelines but not in the more generalizable pipelines.
 This indicates that these feature groups are more likely to produce context-sensitive pipelines.
-Heatmaps, Spectral Histogram, Hidden Markov Models, ALL, and Saccade Length appear in generalizable and context-sensitive pipelines. This further supports the observation that dataset combination is an essential variable for generalizability.
+Heatmaps, Spectral Histogram, Hidden Markov Models, All, and Saccade Length appear in generalizable and context-sensitive pipelines. This further supports the observation that dataset combination is an essential variable for generalizability.

--- a/tables/feature_groups_table.adoc
+++ b/tables/feature_groups_table.adoc
@@ -63,8 +63,8 @@
    ARMA - Saccade Duration, +
    GARCH - Saccade Duration
 
-  | ALL
-  | ALL
+  | All
+  | All features
 
 
 |===


### PR DESCRIPTION
This set out to fix #112. That was just a simple setting, but then I also went through the order of multicitations. Most of them were correct, since they mention a paper for the first time, but some were not in increasing order. 

The rational for using increasing order is quite simple, while one could argue that setting the most relevant, and most important paper first is a good approach, it is an approach that would need more work. This is a simple fix. And if we didn't go through and update the order the jumbled numbers seemed deliberate in a way that could indicate that we had done a prioritisation. 

In the process of checking this I also found two small mistakes and fixed them. 